### PR TITLE
Issue 23

### DIFF
--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -64,12 +64,16 @@ func NewController(informer cache.SharedIndexInformer,
 	klog.Info("Setting up event handlers")
 	// Set up an event handler for when GrafanaDashboard resources change
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: controller.enqueueWorkQueueItem,
+		AddFunc: func(toAdd interface{}) {
+			controller.enqueueWorkQueueItem(toAdd, AddOrUpdate)
+		},
 		UpdateFunc: func(old, new interface{}) {
 
-			controller.enqueueWorkQueueItem(new)
+			controller.enqueueWorkQueueItem(new, AddOrUpdate)
 		},
-		DeleteFunc: controller.enqueueWorkQueueItem,
+		DeleteFunc: func(toDelete interface{}) {
+			controller.enqueueWorkQueueItem(toDelete, Delete)
+		},
 	})
 
 	return controller
@@ -191,12 +195,24 @@ func (c *Controller) syncHandler(item WorkQueueItem) error {
 		return nil
 	}
 
+	if item.itemType == Delete {
+		// object was deleted, so delete from grafana
+		err = c.syncer.deleteObjectById(item.id)
+
+		if err == nil {
+			prometheus.DeletedObjectTotal.WithLabelValues(c.syncer.getType()).Inc()
+			c.recorder.Event(item.originalObject, corev1.EventTypeNormal, SuccessDeleted, MessageResourceDeleted)
+		}
+
+		return err
+	}
+
 	// Get the DataSource resource with this namespace/name
 	runtimeObject, err := c.syncer.getRuntimeObjectByName(name, namespace)
 	if err != nil {
 
 		if k8serrors.IsNotFound(err) {
-			utilruntime.HandleError(fmt.Errorf("Grafana Object '%s' in work queue no longer exists. Deleting", item.key))
+			utilruntime.HandleError(fmt.Errorf("Grafana Object '%s' in work queue no longer exists? Deleting", item.key))
 			prometheus.ErrorTotal.Inc()
 
 			// object was deleted, so delete from grafana
@@ -270,9 +286,10 @@ func (c *Controller) enqueueResyncDeletedObjects() {
 	c.workqueue.AddRateLimited(NewResyncDeletedObjects())
 }
 
-func (c *Controller) enqueueWorkQueueItem(obj interface{}) {
+func (c *Controller) enqueueWorkQueueItem(obj interface{}, itemType WorkQueueItemType) {
 
 	item := c.syncer.createWorkQueueItem(obj)
+	item.itemType = itemType
 
 	if item != nil {
 		c.workqueue.AddRateLimited(*item)

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -196,7 +196,8 @@ func (c *Controller) syncHandler(item WorkQueueItem) error {
 	if err != nil {
 
 		if k8serrors.IsNotFound(err) {
-			utilruntime.HandleError(fmt.Errorf("Grafana Object '%s' in work queue no longer exists", item.key))
+			utilruntime.HandleError(fmt.Errorf("Grafana Object '%s' in work queue no longer exists. Deleting", item.key))
+			prometheus.ErrorTotal.Inc()
 
 			// object was deleted, so delete from grafana
 			err = c.syncer.deleteObjectById(item.id)

--- a/pkg/controllers/work_queue_item.go
+++ b/pkg/controllers/work_queue_item.go
@@ -5,6 +5,7 @@ import "k8s.io/apimachinery/pkg/runtime"
 type WorkQueueItemType int
 
 const (
+	None          = 0
 	AddOrUpdate   = 1
 	Delete        = 2
 	ResyncDeleted = 3
@@ -17,9 +18,9 @@ type WorkQueueItem struct {
 	id             string
 }
 
-func NewWorkQueueItem(itemType WorkQueueItemType, key string, originalObject runtime.Object, id string) WorkQueueItem {
+func NewWorkQueueItem(key string, originalObject runtime.Object, id string) WorkQueueItem {
 	return WorkQueueItem{
-		itemType:       itemType,
+		itemType:       None,
 		key:            key,
 		originalObject: originalObject,
 		id:             id,

--- a/pkg/controllers/work_queue_item.go
+++ b/pkg/controllers/work_queue_item.go
@@ -2,14 +2,24 @@ package controllers
 
 import "k8s.io/apimachinery/pkg/runtime"
 
+type WorkQueueItemType int
+
+const (
+	Update        = 1
+	Delete        = 2
+	ResyncDeleted = 3
+)
+
 type WorkQueueItem struct {
+	itemType       WorkQueueItemType
 	key            string
 	originalObject runtime.Object
 	id             string
 }
 
-func NewWorkQueueItem(key string, originalObject runtime.Object, id string) WorkQueueItem {
+func NewWorkQueueItem(itemType WorkQueueItemType, key string, originalObject runtime.Object, id string) WorkQueueItem {
 	return WorkQueueItem{
+		itemType:       itemType,
 		key:            key,
 		originalObject: originalObject,
 		id:             id,
@@ -18,6 +28,7 @@ func NewWorkQueueItem(key string, originalObject runtime.Object, id string) Work
 
 func NewResyncDeletedObjects() WorkQueueItem {
 	return WorkQueueItem{
+		itemType:       ResyncDeleted,
 		key:            "",
 		originalObject: nil,
 		id:             "",
@@ -25,5 +36,5 @@ func NewResyncDeletedObjects() WorkQueueItem {
 }
 
 func (w *WorkQueueItem) isResyncDeletedObjects() bool {
-	return w.key == "" && w.originalObject == nil && w.id == ""
+	return w.itemType == ResyncDeleted
 }

--- a/pkg/controllers/work_queue_item.go
+++ b/pkg/controllers/work_queue_item.go
@@ -5,7 +5,7 @@ import "k8s.io/apimachinery/pkg/runtime"
 type WorkQueueItemType int
 
 const (
-	Update        = 1
+	AddOrUpdate   = 1
 	Delete        = 2
 	ResyncDeleted = 3
 )

--- a/test/bats_utils.bash
+++ b/test/bats_utils.bash
@@ -272,7 +272,6 @@ validateMetrics() {
     fi
 }
 
-
 #
 # utils
 #

--- a/test/integration_test.bats
+++ b/test/integration_test.bats
@@ -51,6 +51,8 @@ teardown(){
         validateMetrics grafana_controller_grafana_post_latency_ms dashboard
         validateMetrics grafana_controller_updated_object_total dashboard
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "deleting a Dashboard object deletes the Grafana Dashboard" {
@@ -77,6 +79,8 @@ teardown(){
         validateMetrics grafana_controller_grafana_delete_latency_ms dashboard
         validateMetrics grafana_controller_deleted_object_total dashboard
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "deleting a Dashboard while the controller is not running deletes the dashboard in Grafana" {
@@ -105,6 +109,8 @@ teardown(){
 
         validateMetrics grafana_controller_resynced_deleted_total dashboard
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "creating a Dashboard object creates the same dashboard in Grafana" {
@@ -118,6 +124,8 @@ teardown(){
 
         validateEvents Dashboard Synced $(objectNameFromFile $filename)
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "updating a Dashboard object updates the dashboard in Grafana" {
@@ -144,6 +152,8 @@ teardown(){
         validateMetrics grafana_controller_grafana_post_latency_ms dashboard
         validateMetrics grafana_controller_updated_object_total dashboard
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "state is resynced after deleting a dashboard in grafana" {
@@ -160,6 +170,8 @@ teardown(){
 
         [ "$httpStatus" -eq "200" ]
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 #
@@ -179,6 +191,8 @@ teardown(){
         validateMetrics grafana_controller_grafana_post_latency_ms alert-notification
         validateMetrics grafana_controller_updated_object_total alert-notification
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "deleting a AlertNotification object deletes the Grafana AlertNotification" {
@@ -207,6 +221,8 @@ teardown(){
         validateMetrics grafana_controller_grafana_delete_latency_ms alert-notification
         validateMetrics grafana_controller_deleted_object_total alert-notification
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "deleting a AlertNotification while the controller is not running deletes the alert notification in Grafana" {
@@ -237,6 +253,8 @@ teardown(){
 
         validateMetrics grafana_controller_resynced_deleted_total alert-notification
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 
@@ -251,6 +269,8 @@ teardown(){
 
         validateEvents AlertNotification Synced $(objectNameFromFile $filename)
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "updating a AlertNotification object updates the notification in Grafana" {
@@ -276,6 +296,8 @@ teardown(){
         validateMetrics grafana_controller_grafana_put_latency_ms alert-notification
         validateMetrics grafana_controller_updated_object_total alert-notification
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "state is resynced after deleting an alert notification in grafana" {
@@ -293,6 +315,8 @@ teardown(){
 
         [ "$count" -eq "1" ]
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 #
@@ -314,6 +338,8 @@ teardown(){
         validateMetrics grafana_controller_grafana_post_latency_ms datasource
         validateMetrics grafana_controller_updated_object_total datasource
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "deleting a DataSource object deletes the Grafana DataSource" {
@@ -344,6 +370,8 @@ teardown(){
         validateMetrics grafana_controller_grafana_delete_latency_ms datasource
         validateMetrics grafana_controller_deleted_object_total datasource
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "deleting a DataSource while the controller is not running deletes the datasource in Grafana" {
@@ -376,6 +404,8 @@ teardown(){
 
         validateMetrics grafana_controller_resynced_deleted_total datasource
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "creating a DataSource object creates the same datasource in Grafana" {
@@ -389,6 +419,8 @@ teardown(){
 
         validateEvents DataSource Synced $(objectNameFromFile $filename)
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "updating a DataSource object updates the datasource in Grafana" {
@@ -414,6 +446,8 @@ teardown(){
         validateMetrics grafana_controller_grafana_put_latency_ms datasource
         validateMetrics grafana_controller_updated_object_total datasource
     done
+
+    validateMetrics grafana_controller_error_total 0
 }
 
 @test "state is resynced after deleting a datasoure in grafana" {
@@ -432,4 +466,6 @@ teardown(){
 
         [ "$count" -eq "1" ]
     done
+
+    validateMetrics grafana_controller_error_total 0
 }


### PR DESCRIPTION
- Added a type for WorkQueueItem
- Explicitly tell the syncHandler when an object needs to be deleted
- Leave old functionality where an inability to get an item from k8s causes a delete.
- Increment error metric if the  old functionality triggers

Fixes: https://github.com/number101010/kubernetes-grafana-controller/issues/23